### PR TITLE
Close cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - sh -e /etc/init.d/xvfb start
 
 before_script:
-  - wget http://chromedriver.storage.googleapis.com/2.35/chromedriver_linux64.zip
+  - wget http://chromedriver.storage.googleapis.com/2.40/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip
   - export PATH=$PATH:$PWD
   - ./tool/travis-setup.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: dart
 sudo: required
 dist: trusty
 addons:
+  chrome: stable
   apt:
     sources:
       - google-chrome

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - sh -e /etc/init.d/xvfb start
 
 before_script:
-  - wget http://chromedriver.storage.googleapis.com/2.40/chromedriver_linux64.zip
+  - wget http://chromedriver.storage.googleapis.com/2.46/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip
   - export PATH=$PATH:$PWD
   - ./tool/travis-setup.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0
+
+- No longer expose `close` and `onClose` on an `SseConnection`. This is simply
+  handled by the underlying `stream` / `sink`.
+- Fix a bug where resources of the `SseConnection` were not properly closed.
+
 ## 1.0.0
 
 - Internal cleanup.

--- a/lib/server/sse_handler.dart
+++ b/lib/server/sse_handler.dart
@@ -96,7 +96,7 @@ class SseHandler {
   }
 
   shelf.Response _createSseConnection(shelf.Request req, String path) {
-    if (_isClosed) return null;
+    if (_isClosed) return shelf.Response.notFound('');
     req.hijack((channel) async {
       var sink = utf8.encoder.startChunkedConversion(channel.sink);
       sink.add(_sseHeaders(req.headers['origin']));
@@ -115,7 +115,7 @@ class SseHandler {
 
       _connectionController.add(connection);
     });
-    return null;
+    return shelf.Response.notFound('');
   }
 
   String _getOriginalPath(shelf.Request req) => req.requestedUri.path;

--- a/lib/server/sse_handler.dart
+++ b/lib/server/sse_handler.dart
@@ -96,7 +96,7 @@ class SseHandler {
   }
 
   shelf.Response _createSseConnection(shelf.Request req, String path) {
-    if (_isClosed) return shelf.Response.notFound('');
+    if (_isClosed) return null;
     req.hijack((channel) async {
       var sink = utf8.encoder.startChunkedConversion(channel.sink);
       sink.add(_sseHeaders(req.headers['origin']));
@@ -115,7 +115,7 @@ class SseHandler {
 
       _connectionController.add(connection);
     });
-    return shelf.Response.notFound('');
+    return null;
   }
 
   String _getOriginalPath(shelf.Request req) => req.requestedUri.path;

--- a/lib/server/sse_handler.dart
+++ b/lib/server/sse_handler.dart
@@ -134,8 +134,7 @@ class SseHandler {
       var clientId = req.url.queryParameters['sseClientId'];
       var message = await req.readAsString();
       var jsonObject = json.decode(message) as String;
-      var connection = _connections[clientId];
-      if (connection != null) connection._incomingController.add(jsonObject);
+      _connections[clientId]?._incomingController?.add(jsonObject);
     } catch (e, st) {
       _logger.fine('Failed to handle incoming message. $e $st');
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,6 @@ dependencies:
   async: ^2.0.8
   http: ^0.12.0+1
   logging: ^0.11.3+2
-  pedantic: ^1.4.0
   stream_channel: ^1.6.8
   shelf: ^0.7.4
   uuid: ^1.0.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sse
-version: 1.0.0
+version: 2.0.0
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/sse
 description: >-

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   async: ^2.0.8
   http: ^0.12.0+1
   logging: ^0.11.3+2
+  pedantic: ^1.4.0
   stream_channel: ^1.6.8
   shelf: ^0.7.4
   uuid: ^1.0.3

--- a/test/sse_test.dart
+++ b/test/sse_test.dart
@@ -83,7 +83,31 @@ void main() {
     var closeButton = await webdriver.findElement(const By.tagName('button'));
     await closeButton.click();
 
-    // Stream should complete.
+    // Should complete since the connection is closed.
+    await connection.stream.toList();
+    expect(handler.numberOfClients, 0);
+  });
+
+  test('Cancelling the listener closes the conneciton', () async {
+    expect(handler.numberOfClients, 0);
+    await webdriver.get('http://localhost:${server.port}');
+    var connection = await handler.connections.next;
+    expect(handler.numberOfClients, 1);
+
+    var sub = connection.stream.listen((_) {});
+    await sub.cancel();
+    await pumpEventQueue();
+    expect(handler.numberOfClients, 0);
+  });
+
+  test('Can close the handler which closes the connections', () async {
+    expect(handler.numberOfClients, 0);
+    await webdriver.get('http://localhost:${server.port}');
+    var connection = await handler.connections.next;
+    expect(handler.numberOfClients, 1);
+
+    handler.close();
+    // Should complete since the connection is closed.
     await connection.stream.toList();
     expect(handler.numberOfClients, 0);
   });

--- a/test/sse_test.dart
+++ b/test/sse_test.dart
@@ -88,7 +88,7 @@ void main() {
     expect(handler.numberOfClients, 0);
   });
 
-  test('Cancelling the listener closes the conneciton', () async {
+  test('Cancelling the listener closes the connection', () async {
     expect(handler.numberOfClients, 0);
     await webdriver.get('http://localhost:${server.port}');
     var connection = await handler.connections.next;
@@ -110,6 +110,21 @@ void main() {
     // Should complete since the connection is closed.
     await connection.stream.toList();
     expect(handler.numberOfClients, 0);
+  });
+
+  test('Closing the handler prevents new connections', () async {
+    expect(handler.numberOfClients, 0);
+    await webdriver.get('http://localhost:${server.port}');
+    var connection = await handler.connections.next;
+    expect(handler.numberOfClients, 1);
+
+    handler.close();
+    // Should complete since the connection is closed.
+    await connection.stream.toList();
+    assert(handler.numberOfClients == 0);
+
+    await webdriver.get('http://localhost:${server.port}');
+    expect(await handler.connections.hasNext, isFalse);
   });
 
   test('Disconnects when navigating away', () async {

--- a/test/sse_test.dart
+++ b/test/sse_test.dart
@@ -17,6 +17,21 @@ void main() {
   HttpServer server;
   WebDriver webdriver;
   SseHandler handler;
+  Process chromeDriver;
+
+  setUpAll(() async {
+    try {
+      chromeDriver = await Process.start(
+          'chromedriver', ['--port=4444', '--url-base=wd/hub']);
+    } catch (e) {
+      throw StateError(
+          'Could not start ChromeDriver. Is it installed?\nError: $e');
+    }
+  });
+
+  tearDownAll(() {
+    chromeDriver.kill();
+  });
 
   setUp(() async {
     handler = SseHandler(Uri.parse('/test'));

--- a/test/sse_test.dart
+++ b/test/sse_test.dart
@@ -43,7 +43,11 @@ void main() {
             listDirectories: true, defaultDocument: 'index.html'));
 
     server = await io.serve(cascade.handler, 'localhost', 0);
-    webdriver = await createDriver();
+    webdriver = await createDriver(desired: {
+      'chromeOptions': {
+        'args': ['--headless']
+      }
+    });
   });
 
   tearDown(() async {

--- a/test/sse_test.dart
+++ b/test/sse_test.dart
@@ -55,12 +55,12 @@ void main() {
     var connections = handler.connections;
     await webdriver.get('http://localhost:${server.port}');
     var connectionA = await connections.next;
+    connectionA.sink.add('foo');
+    expect(await connectionA.stream.first, 'foo');
+
     await webdriver.get('http://localhost:${server.port}');
     var connectionB = await connections.next;
-
-    connectionA.sink.add('foo');
     connectionB.sink.add('bar');
-    await connectionA.onClose;
     expect(await connectionB.stream.first, 'bar');
   });
 
@@ -69,8 +69,8 @@ void main() {
     await webdriver.get('http://localhost:${server.port}');
     var connection = await handler.connections.next;
     expect(handler.numberOfClients, 1);
-    connection.close();
-    await connection.onClose;
+    await connection.sink.close();
+    await pumpEventQueue();
     expect(handler.numberOfClients, 0);
   });
 
@@ -83,7 +83,8 @@ void main() {
     var closeButton = await webdriver.findElement(const By.tagName('button'));
     await closeButton.click();
 
-    await connection.onClose;
+    // Stream should complete.
+    await connection.stream.toList();
     expect(handler.numberOfClients, 0);
   });
 

--- a/test/sse_test.dart
+++ b/test/sse_test.dart
@@ -119,33 +119,6 @@ void main() {
     expect(handler.numberOfClients, 0);
   });
 
-  test('Can close the handler which closes the connections', () async {
-    expect(handler.numberOfClients, 0);
-    await webdriver.get('http://localhost:${server.port}');
-    var connection = await handler.connections.next;
-    expect(handler.numberOfClients, 1);
-
-    handler.close();
-    // Should complete since the connection is closed.
-    await connection.stream.toList();
-    expect(handler.numberOfClients, 0);
-  });
-
-  test('Closing the handler prevents new connections', () async {
-    expect(handler.numberOfClients, 0);
-    await webdriver.get('http://localhost:${server.port}');
-    var connection = await handler.connections.next;
-    expect(handler.numberOfClients, 1);
-
-    handler.close();
-    // Should complete since the connection is closed.
-    await connection.stream.toList();
-    assert(handler.numberOfClients == 0);
-
-    await webdriver.get('http://localhost:${server.port}');
-    expect(await handler.connections.hasNext, isFalse);
-  });
-
   test('Disconnects when navigating away', () async {
     await webdriver.get('http://localhost:${server.port}');
     expect(handler.numberOfClients, 1);

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -23,10 +23,6 @@ if [[ $ANALYSIS_STATUS -ne 0 ]]; then
   STATUS=$ANALYSIS_STATUS
 fi
 
-# Start chromedriver.
-chromedriver --port=4444 --url-base=wd/hub &
-PIDC=$!
-
 # Run tests.
 pub run test -r expanded -p vm -j 1
 TEST_STATUS=$?


### PR DESCRIPTION
- Remove `close` and `onClose` from `SseConnection`
  - This functionality is replaced by the underlying `sink` / `stream`
- Fix an issue where the `Sink` within the `SseConnection` wasn't closed
- Store underlying connections in a map to improve performance
- Rev package version
- Make local testing easier