### PR TITLE
Add an SseProxyHandler

### DIFF
--- a/lib/server/sse_handler.dart
+++ b/lib/server/sse_handler.dart
@@ -6,9 +6,11 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:async/async.dart';
+import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
 import 'package:pedantic/pedantic.dart';
 import 'package:shelf/shelf.dart' as shelf;
+import 'package:shelf_proxy/shelf_proxy.dart' as shelf_proxy;
 import 'package:stream_channel/stream_channel.dart';
 
 String _sseHeaders(String origin) => 'HTTP/1.1 200 OK\r\n'
@@ -142,5 +144,88 @@ class SseHandler {
       'access-control-allow-credentials': 'true',
       'access-control-allow-origin': req.headers['origin']
     });
+  }
+}
+
+/// [SseProxyHandler] proxies two-way communications of JSON encodable data
+/// between clients and an [SseHandler].
+///
+/// This handler provides the same communication interface as [SseHandler], but
+/// simply forwards data back and forth between clients and the actual server.
+class SseProxyHandler {
+  final _httpClient = http.Client();
+  shelf.Handler _incomingMessageProxyHandler;
+  final _logger = Logger('SseProxyHandler');
+  final String _proxyName;
+  final Uri _proxyUri;
+  final Uri _serverUri;
+
+  /// Creates an SSE proxy handler that will handle EventSource requests to
+  /// [proxyUri] by proxying them to [serverUri].
+  SseProxyHandler(Uri proxyUri, Uri serverUri, {String proxyName})
+      : _proxyUri = proxyUri,
+        _serverUri = serverUri,
+        _proxyName = proxyName;
+
+  shelf.Handler get handler => _handle;
+
+  Future<shelf.Response> _createSseConnection(
+      shelf.Request req, String path) async {
+    final serverReq = http.StreamedRequest(
+        req.method, _serverUri.replace(query: req.requestedUri.query))
+      ..followRedirects = false
+      ..headers.addAll(req.headers)
+      ..headers['Host'] = _serverUri.authority
+      ..sink.close();
+
+    final serverResponse = await _httpClient.send(serverReq);
+
+    req.hijack((channel) {
+      final sink = utf8.encoder.startChunkedConversion(channel.sink)
+        ..add(_sseHeaders(req.headers['origin']));
+
+      StreamSubscription serverSseSub;
+      StreamSubscription reqChannelSub;
+
+      serverSseSub =
+          utf8.decoder.bind(serverResponse.stream).listen(sink.add, onDone: () {
+        reqChannelSub?.cancel();
+        sink.close();
+      });
+
+      reqChannelSub = channel.stream.listen((_) {
+        // SSE is unidirectional.
+      }, onDone: () {
+        serverSseSub?.cancel();
+        sink.close();
+      });
+    });
+    return shelf.Response.notFound('');
+  }
+
+  Future<shelf.Response> _handle(shelf.Request req) async {
+    final path = req.requestedUri.path;
+    if (path != _proxyUri.path) {
+      return shelf.Response.notFound('');
+    }
+
+    if (req.headers['accept'] == 'text/event-stream' && req.method == 'GET') {
+      return _createSseConnection(req, path);
+    }
+
+    if (req.headers['accept'] != 'text/event-stream' && req.method == 'POST') {
+      return _handleIncomingMessage(req);
+    }
+
+    return shelf.Response.notFound('');
+  }
+
+  Future<shelf.Response> _handleIncomingMessage(shelf.Request req) async {
+    _incomingMessageProxyHandler ??= shelf_proxy.proxyHandler(
+      _serverUri,
+      client: _httpClient,
+      proxyName: _proxyName,
+    );
+    return _incomingMessageProxyHandler(req);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   pedantic: ^1.4.0
   stream_channel: '>=1.6.8 <3.0.0'
   shelf: ^0.7.4
+  shelf_proxy: ^0.1.0
   uuid: ^2.0.0
 
 dev_dependencies:

--- a/test/sse_proxy_test.dart
+++ b/test/sse_proxy_test.dart
@@ -1,0 +1,148 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('vm')
+@Timeout(Duration(seconds: 5))
+import 'dart:async';
+import 'dart:io';
+
+import 'package:shelf/shelf.dart' as shelf;
+import 'package:shelf/shelf_io.dart' as io;
+import 'package:shelf_static/shelf_static.dart';
+import 'package:sse/server/sse_handler.dart';
+import 'package:test/test.dart';
+import 'package:webdriver/io.dart';
+
+void main() {
+  Process chromeDriver;
+  HttpServer proxy;
+  HttpServer server;
+  SseHandler serverSse;
+  WebDriver webdriver;
+
+  setUpAll(() async {
+    try {
+      chromeDriver = await Process.start(
+          'chromedriver', ['--port=4444', '--url-base=wd/hub']);
+    } catch (e) {
+      throw StateError(
+          'Could not start ChromeDriver. Is it installed?\nError: $e');
+    }
+  });
+
+  tearDownAll(() {
+    chromeDriver.kill();
+  });
+
+  setUp(() async {
+    const ssePath = '/test';
+
+    final staticWebHandler = createStaticHandler('test/web',
+        listDirectories: true, defaultDocument: 'index.html');
+
+    serverSse = SseHandler(Uri.parse(ssePath));
+    final serverCascade = shelf.Cascade().add(serverSse.handler);
+    server = await io.serve(serverCascade.handler, 'localhost', 0);
+
+    final proxySse = SseProxyHandler(Uri.parse(ssePath),
+        Uri.parse('http://localhost:${server.port}$ssePath'));
+    final proxyCascade = shelf.Cascade()
+        .add(proxySse.handler)
+        .add(_faviconHandler)
+        .add(staticWebHandler);
+    proxy = await io.serve(proxyCascade.handler, 'localhost', 0);
+
+    webdriver = await createDriver(desired: {
+      'chromeOptions': {
+        'args': ['--headless']
+      }
+    });
+  });
+
+  tearDown(() async {
+    await webdriver.quit();
+    await proxy.close();
+    await server.close();
+  });
+
+  test('Can round trip messages', () async {
+    await webdriver.get('http://localhost:${proxy.port}');
+    var connection = await serverSse.connections.next;
+    connection.sink.add('blah');
+    expect(await connection.stream.first, 'blah');
+  });
+
+  test('Multiple clients can connect', () async {
+    var connections = serverSse.connections;
+    await webdriver.get('http://localhost:${proxy.port}');
+    await connections.next;
+    await webdriver.get('http://localhost:${proxy.port}');
+    await connections.next;
+  });
+
+  test('Routes data correctly', () async {
+    var connections = serverSse.connections;
+    await webdriver.get('http://localhost:${proxy.port}');
+    var connectionA = await connections.next;
+    connectionA.sink.add('foo');
+    expect(await connectionA.stream.first, 'foo');
+
+    await webdriver.get('http://localhost:${proxy.port}');
+    var connectionB = await connections.next;
+    connectionB.sink.add('bar');
+    expect(await connectionB.stream.first, 'bar');
+  });
+
+  test('Can close from the server', () async {
+    expect(serverSse.numberOfClients, 0);
+    await webdriver.get('http://localhost:${proxy.port}');
+    var connection = await serverSse.connections.next;
+    expect(serverSse.numberOfClients, 1);
+    await connection.sink.close();
+    await pumpEventQueue();
+    expect(serverSse.numberOfClients, 0);
+  });
+
+  test('Can close from the client-side', () async {
+    expect(serverSse.numberOfClients, 0);
+    await webdriver.get('http://localhost:${proxy.port}');
+    var connection = await serverSse.connections.next;
+    expect(serverSse.numberOfClients, 1);
+
+    var closeButton = await webdriver.findElement(const By.tagName('button'));
+    await closeButton.click();
+
+    // Should complete since the connection is closed.
+    await connection.stream.toList();
+    expect(serverSse.numberOfClients, 0);
+  });
+
+  test('Cancelling the listener closes the connection', () async {
+    expect(serverSse.numberOfClients, 0);
+    await webdriver.get('http://localhost:${proxy.port}');
+    var connection = await serverSse.connections.next;
+    expect(serverSse.numberOfClients, 1);
+
+    var sub = connection.stream.listen((_) {});
+    await sub.cancel();
+    await pumpEventQueue();
+    expect(serverSse.numberOfClients, 0);
+  });
+
+  test('Disconnects when navigating away', () async {
+    await webdriver.get('http://localhost:${proxy.port}');
+    await serverSse.connections.next;
+    expect(serverSse.numberOfClients, 1);
+
+    await webdriver.get('chrome://version/');
+    expect(serverSse.numberOfClients, 0);
+  });
+}
+
+FutureOr<shelf.Response> _faviconHandler(shelf.Request request) {
+  if (request.url.path.endsWith('favicon.ico')) {
+    return shelf.Response.ok('');
+  }
+  return shelf.Response.notFound('');
+}


### PR DESCRIPTION
We've got a `webdev_proxy` tool internally that sets up a simple proxy in front of `webdev serve` just so that we can rewrite certain paths to `/index.html`, and in order to get that working we had to write a small proxy version of `SseHandler` for the `/$sseHandler` endpoint.

I thought I'd offer it up here, but I also understand that you may not want to maintain something that you aren't also actively using. If that's the case feel free to close and we will keep it in our `webdev_proxy` package for now (we're hoping to open-source that package anyway).

@grouma 