### PR TITLE
Make isInKeepAlivePeriod as private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.1.1
+
+- Make `isInKeepAlive` on `SseConnection` private.
+
+* Note that this is a breaking change but in actuality no one should be
+  depending on this API.
+
 ## 3.1.0
 
 - Add optional `keepAlive` parameter to the `SseHandler`. If `keepAlive` is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 - Make `isInKeepAlive` on `SseConnection` private.
 
-** Note that this is a breaking change but in actuality no one should be
-  depending on this API.
+**Note that this is a breaking change but in actuality no one should be
+  depending on this API.**
 
 ## 3.1.0
 
@@ -16,8 +16,8 @@
 
 - Add retry logic.
 
-** Possible Breaking Change ** Error messages may now be delayed up to 5 seconds
-in the client.
+**Possible Breaking Change Error messages may now be delayed up to 5 seconds
+  in the client.**
 
 ## 2.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Make `isInKeepAlive` on `SseConnection` private.
 
-* Note that this is a breaking change but in actuality no one should be
+** Note that this is a breaking change but in actuality no one should be
   depending on this API.
 
 ## 3.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sse
-version: 3.1.0
+version: 3.1.1
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/sse
 description: >-


### PR DESCRIPTION
This method slipped through in https://github.com/dart-lang/sse/pull/19 and should really be private.

Note that this is technically a breaking change but I'm not adhering to semver. 