### PR TITLE
Proper close on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.1.2
+
+- Fix an issue where the `SseClient` would not send a `done` event when there
+  was an error with the SSE connection.
+
 ## 3.1.1
 
 - Make `isInKeepAlive` on `SseConnection` private.

--- a/lib/client/sse_client.dart
+++ b/lib/client/sse_client.dart
@@ -47,7 +47,7 @@ class SseClient extends StreamChannelMixin<String> {
         // Allow for a retry to connect before giving up.
         _errorTimer = Timer(const Duration(seconds: 5), () {
           _incomingController.addError(error);
-          _eventSource.close();
+          close();
         });
       }
     });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sse
-version: 3.1.2-dev
+version: 3.1.2
 homepage: https://github.com/dart-lang/sse
 description: >-
   Provides client and server functionality for setting up bi-directional


### PR DESCRIPTION
Simple change. A little difficult to test since we don't have infrastructure to get the client state in the test.

Towards https://github.com/flutter/devtools/issues/1589