### PR TITLE
Fix keepAlive reconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.1
+
+- Fix an issue where `keepAlive` would only allow a single reconnection.
+
 ## 3.2.0
 
 - Re-expose `isInKeepAlivePeriod` flag on `SseConnection`. This flag will be

--- a/lib/src/server/sse_handler.dart
+++ b/lib/src/server/sse_handler.dart
@@ -163,16 +163,15 @@ class SseHandler {
         unawaited(connection._closedCompleter.future.then((_) {
           _connections.remove(clientId);
         }));
-        // Remove connection when it is remotely closed or the stream is
-        // cancelled.
-        channel.stream.listen((_) {
-          // SSE is unidirectional. Responses are handled through POST requests.
-        }, onDone: () {
-          connection._handleDisconnect();
-        });
-
         _connectionController.add(connection);
       }
+      // Remove connection when it is remotely closed or the stream is
+      // cancelled.
+      channel.stream.listen((_) {
+        // SSE is unidirectional. Responses are handled through POST requests.
+      }, onDone: () {
+        _connections[clientId]?._handleDisconnect();
+      });
     });
     return shelf.Response.notFound('');
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sse
-version: 3.2.0
+version: 3.2.1
 homepage: https://github.com/dart-lang/sse
 description: >-
   Provides client and server functionality for setting up bi-directional


### PR DESCRIPTION
Fix an issue where `keepAlive` would only allow a single reconnection.