### PR TITLE
Fix state error with keep alive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.2.2
+
+- Fix an issue where `keepAlive` may cause state errors when attempting to
+  send messages on a closed stream.
+
 ## 3.2.1
 
 - Fix an issue where `keepAlive` would only allow a single reconnection.

--- a/lib/src/server/sse_handler.dart
+++ b/lib/src/server/sse_handler.dart
@@ -68,6 +68,11 @@ class SseConnection extends StreamChannelMixin<String> {
       // Peek the data so we don't remove it from the stream if we're unable to
       // send it.
       final data = await outgoingStreamQueue.peek;
+
+      // Ignore outgoing messages since the connection may have closed while
+      // waiting for the keep alive.
+      if (_closedCompleter.isCompleted) break;
+
       try {
         // JSON encode the message to escape new lines.
         _sink.add('data: ${json.encode(data)}\n');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sse
-version: 3.2.1
+version: 3.2.2
 homepage: https://github.com/dart-lang/sse
 description: >-
   Provides client and server functionality for setting up bi-directional


### PR DESCRIPTION
Theory on what's going on:

- The keep alive [timer](https://github.com/dart-lang/sse/blame/a0ac454fac573bba5d8c38a11e52c8f68e416bc9/lib/src/server/sse_handler.dart#L112) closes the outgoing stream controller
- The close handler is asynchronous and not [awaited](https://github.com/dart-lang/sse/blame/a0ac454fac573bba5d8c38a11e52c8f68e416bc9/lib/src/server/sse_handler.dart#L120)
- While the `outgoingController` is closed, pending messages are [consumed](https://github.com/dart-lang/sse/blame/a0ac454fac573bba5d8c38a11e52c8f68e416bc9/lib/src/server/sse_handler.dart#L60) by the `_setUpListener`
- The messages are placed on a closed [sink](https://github.com/dart-lang/sse/blame/a0ac454fac573bba5d8c38a11e52c8f68e416bc9/lib/src/server/sse_handler.dart#L73)
- An error is thrown but since the `_closedCompleter` is completed the error is not properly [handled](https://github.com/dart-lang/sse/blame/a0ac454fac573bba5d8c38a11e52c8f68e416bc9/lib/src/server/sse_handler.dart#L78)


Towards https://github.com/dart-lang/webdev/issues/943