### PR TITLE
Add onClose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.3.0
+
+- Add an `onClose` event to the `SseConnection`. This allows consumers to
+  listen to this event in lue of `sseConnection.sink.done` as that is not
+  guaranteed to fire.
+
 ## 3.2.2
 
 - Fix an issue where `keepAlive` may cause state errors when attempting to

--- a/lib/src/server/sse_handler.dart
+++ b/lib/src/server/sse_handler.dart
@@ -41,6 +41,11 @@ class SseConnection extends StreamChannelMixin<String> {
 
   final _closedCompleter = Completer<void>();
 
+  /// Completes when the [SseConnection] closes.
+  ///
+  /// This is guaranteed to fire unlike `this.sink.close`;
+  Future<void> get onClose => _closedCompleter.future;
+
   /// Creates an [SseConnection] for the supplied [_sink].
   ///
   /// If [keepAlive] is supplied, the connection will remain active for this

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sse
-version: 3.2.2
+version: 3.3.0
 homepage: https://github.com/dart-lang/sse
 description: >-
   Provides client and server functionality for setting up bi-directional


### PR DESCRIPTION
Towards dart-lang/webdev#943

The documentation for `sink.done` states that:

>  Otherwise, the returned future will complete when either:
>   
>    *  all events have been processed and the sink has been closed, or
>    * the sink has otherwise been stopped from handling more events
>     (for example by canceling a stream subscription).

This means that listening to `sink.done` may not fire and is not a good signal for consumers of the `SseConnection` to stop placing events on the sink. Add a new `onClose` event which fires immediately upon close of the sink to give the required signal.