### PR TITLE
Support shutting down the handler ignoring any keepAlive periods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.5.0
+
+- Add new `shutdown` methods on `SseHandler` and `SseConnection` to allow closing
+  connections immediately, ignoring any keep-alive periods.
+
 ## 3.4.0
 
 - Remove `onClose` from `SseConnection` and ensure the corresponding

--- a/lib/src/server/sse_handler.dart
+++ b/lib/src/server/sse_handler.dart
@@ -115,10 +115,11 @@ class SseConnection extends StreamChannelMixin<String> {
     if (_keepAlive == null) {
       // Close immediately if we're not keeping alive.
       _close();
-    } else if (!isInKeepAlivePeriod) {
-      // Otherwise if we didn't already have an active timer, set a timer to
-      // close after the timeout period. If the connection comes back, this will
-      // be cancelled and all messages left in the queue tried again.
+    } else if (!isInKeepAlivePeriod && !_closedCompleter.isCompleted) {
+      // Otherwise if we didn't already have an active timer and we've not already
+      // been completely closed, set a timer to close after the timeout period.
+      // If the connection comes back, this will be cancelled and all messages left
+      // in the queue tried again.
       _keepAliveTimer = Timer(_keepAlive, _close);
     }
   }
@@ -126,6 +127,9 @@ class SseConnection extends StreamChannelMixin<String> {
   void _close() {
     if (!_closedCompleter.isCompleted) {
       _closedCompleter.complete();
+      // Cancel any existing timer in case we were told to explicitly shut down
+      // to avoid keeping the process alive.
+      _keepAliveTimer?.cancel();
       _sink.close();
       if (!_outgoingController.isClosed) {
         _outgoingStreamQueue.cancel(immediate: true);

--- a/lib/src/server/sse_handler.dart
+++ b/lib/src/server/sse_handler.dart
@@ -134,6 +134,11 @@ class SseConnection extends StreamChannelMixin<String> {
       if (!_incomingController.isClosed) _incomingController.close();
     }
   }
+
+  /// Immediately close the connection, ignoring any keepAlive period.
+  void shutdown() {
+    _close();
+  }
 }
 
 /// [SseHandler] handles requests on a user defined path to create
@@ -228,6 +233,13 @@ class SseHandler {
       // Firefox does not set header "origin".
       // https://bugzilla.mozilla.org/show_bug.cgi?id=1508661
       req.headers['origin'] ?? req.headers['host'];
+
+  /// Immediately close all connections, ignoring any keepAlive periods.
+  void shutdown() {
+    for (final connection in _connections.values) {
+      connection.shutdown();
+    }
+  }
 }
 
 void closeSink(SseConnection connection) => connection._sink.close();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sse
-version: 3.4.0
+version: 3.5.0
 homepage: https://github.com/dart-lang/sse
 description: >-
   Provides client and server functionality for setting up bi-directional

--- a/test/sse_test.dart
+++ b/test/sse_test.dart
@@ -241,8 +241,8 @@ void main() {
       // Close the underlying connection.
       handler.shutdown();
 
-      // The isInKeepAlivePeriod flag may only be set for a short period because
-      // the client may connect very quickly, so only pump until it changes.
+      // Wait for a short period to allow the connection to close, but not
+      // long enough that the 30second keep-alive may have expired.
       var maxPumps = 50;
       while (handler.numberOfClients > 0 && maxPumps-- > 0) {
         await pumpEventQueue(times: 1);


### PR DESCRIPTION
I think we need something like this in order to fix https://github.com/dart-lang/webdev/issues/950. The issue is that the keepAlive period fires for the injected client handler and prevents the daemon from ending until the keepAlive timer runs out.

This exposes a `shutdown` method on the handler that will close all connections ignoring the keepAlive.