### PR TITLE
Deprecate onConnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.7.0
+
+- Deprecate the client's `onOpen` getter. Instead users should use `onConnect`.
+
 ## 3.6.1
 
 - Drop dependency on `package:uuid`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.7.0
 
-- Deprecate the client's `onOpen` getter. Instead users should use `onConnect`.
+- Deprecate the client's `onOpen` getter. Messages will now be buffered until
+  a connection is established.
 
 ## 3.6.1
 

--- a/lib/client/sse_client.dart
+++ b/lib/client/sse_client.dart
@@ -56,7 +56,10 @@ class SseClient extends StreamChannelMixin<String> {
     });
   }
 
+  @Deprecated('Use onConnect instead.')
   Stream<Event> get onOpen => _eventSource.onOpen;
+
+  Future<void> get onConnect => _eventSource.onOpen.first;
 
   /// Add messages to this [StreamSink] to send them to the server.
   ///

--- a/lib/client/sse_client.dart
+++ b/lib/client/sse_client.dart
@@ -37,10 +37,11 @@ class SseClient extends StreamChannelMixin<String> {
     _eventSource =
         EventSource('$serverUrl?sseClientId=$clientId', withCredentials: true);
     _serverUrl = '$serverUrl?sseClientId=$clientId';
-    _outgoingController.stream
-        .listen(_onOutgoingMessage, onDone: _onOutgoingDone);
+    _eventSource.onOpen.first.whenComplete(() => _outgoingController.stream
+        .listen(_onOutgoingMessage, onDone: _onOutgoingDone));
     _eventSource.addEventListener('message', _onIncomingMessage);
     _eventSource.addEventListener('control', _onIncomingControlMessage);
+
     _eventSource.onOpen.listen((_) {
       _errorTimer?.cancel();
     });

--- a/lib/client/sse_client.dart
+++ b/lib/client/sse_client.dart
@@ -56,10 +56,10 @@ class SseClient extends StreamChannelMixin<String> {
     });
   }
 
-  @Deprecated('Use onConnect instead.')
+  @Deprecated(
+      'Outgoing messages are now buffered until a connection is established.'
+      'This should no longer be required and will be removed.')
   Stream<Event> get onOpen => _eventSource.onOpen;
-
-  Future<void> get onConnect => _eventSource.onOpen.first;
 
   /// Add messages to this [StreamSink] to send them to the server.
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sse
-version: 3.6.1
+version: 3.7.0
 homepage: https://github.com/dart-lang/sse
 description: >-
   Provides client and server functionality for setting up bi-directional


### PR DESCRIPTION
The `onOpen` API is problematic with the default reconnect logic of `EventSource`s. When an `EventSource` reconnects, an `onOpen` event will be sent. Users shouldn't have to worry about these events as we try to model `SseConnetions` as simple a simple output stream and input sink. The current `Stream` API of `onOpen` nudges consumers in the wrong direction.