### PR TITLE
update to the latest shelf and remove dead code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ addons:
 
 dart:
   - dev
-  - 2.2.0
 
 with_content_shell: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.8.3-dev
+
+- Require the latest shelf and remove dead code.
+
 ## 3.8.2
 
 - Complete `onConnected` with an error if the `SseClient` receives an error

--- a/lib/src/server/sse_handler.dart
+++ b/lib/src/server/sse_handler.dart
@@ -97,7 +97,7 @@ class SseConnection extends StreamChannelMixin<String> {
         _sink.add('data: ${json.encode(data)}\n');
         _sink.add('\n');
         await _outgoingStreamQueue.next; // Consume from stream if no errors.
-      } catch (_) {
+      } on StateError catch (_) {
         if (_keepAlive == null || _closedCompleter.isCompleted) {
           rethrow;
         }

--- a/lib/src/server/sse_handler.dart
+++ b/lib/src/server/sse_handler.dart
@@ -97,7 +97,7 @@ class SseConnection extends StreamChannelMixin<String> {
         _sink.add('data: ${json.encode(data)}\n');
         _sink.add('\n');
         await _outgoingStreamQueue.next; // Consume from stream if no errors.
-      } catch (StateError) {
+      } catch (_) {
         if (_keepAlive == null || _closedCompleter.isCompleted) {
           rethrow;
         }
@@ -239,7 +239,6 @@ class SseHandler {
         _connections[clientId]?._handleDisconnect();
       });
     });
-    return shelf.Response.notFound('');
   }
 
   String _getOriginalPath(shelf.Request req) => req.requestedUri.path;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sse
-version: 3.8.2
+version: 3.8.3-dev
 homepage: https://github.com/dart-lang/sse
 description: >-
   Provides client and server functionality for setting up bi-directional
@@ -12,12 +12,16 @@ environment:
 dependencies:
   async: ^2.0.8
   collection: ^1.0.0
-  logging: ^0.11.3+2
+  logging: '>=0.11.3+2 <2.0.0'
   pedantic: ^1.4.0
   stream_channel: '>=1.6.8 <3.0.0'
-  shelf: ^0.7.4
+  shelf: ^1.1.0
 
 dev_dependencies:
-  shelf_static: ^0.2.8
+  shelf_static: '>=0.2.8 <2.0.0'
   test: ^1.5.3
   webdriver: ^2.1.0
+
+dependency_overrides:
+  shelf:
+    git: https://github.com/dart-lang/shelf.git


### PR DESCRIPTION
`Request.hijack` now returns the `Never` type and so the compiler knows that no code after invoking it is reachable.