### PR TITLE
keepAlive for SocketExceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 4.1.1-dev
 
+- Apply `keepAlive` logic to `SocketException`s.
+
 ## 4.1.0
 
 - Limit the number of concurrent requests to prevent Chrome from automatically


### PR DESCRIPTION
Internally we are seeing crashes due to unhandled `SocketException`s. It's not clear to me if the `keepAlive` logic will handle these errors but it's worth experimenting. We should wait to publish this package until we confirm this resolves the problem.