### PR TITLE
switch to using package:lints

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         # Add macos-latest and/or windows-latest if relevant for this package.
         os: [ubuntu-latest]
-        sdk: [2.12.0, dev]
+        sdk: [stable, dev]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         # Add macos-latest and/or windows-latest if relevant for this package.
         os: [ubuntu-latest]
-        sdk: [stable, dev]
+        sdk: [2.15.0, dev]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 4.1.1-dev
 
 - Apply `keepAlive` logic to `SocketException`s.
+- Switch from using `package:pedantic` to `package:lints`
+- Rev the minimum required SDK to 2.15.
 
 ## 4.1.0
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,5 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
+
 analyzer:
   strong-mode:
     implicit-casts: false
@@ -7,6 +8,7 @@ analyzer:
     unused_element: error
     unused_import: error
     unused_local_variable: error
+
 linter:
   rules:
     - always_declare_return_types

--- a/lib/src/server/sse_handler.dart
+++ b/lib/src/server/sse_handler.dart
@@ -9,7 +9,6 @@ import 'dart:io';
 import 'package:async/async.dart';
 import 'package:collection/collection.dart';
 import 'package:logging/logging.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:stream_channel/stream_channel.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,18 +7,18 @@ description: >-
   requests.
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.15.0 <3.0.0'
 
 dependencies:
   async: ^2.0.8
   collection: ^1.0.0
   logging: '>=0.11.3+2 <2.0.0'
   pool: ^1.5.0
-  pedantic: ^1.4.0
-  stream_channel: '>=1.6.8 <3.0.0'
   shelf: ^1.1.0
+  stream_channel: '>=1.6.8 <3.0.0'
 
 dev_dependencies:
+  lints: ^1.0.0
   shelf_static: '>=0.2.8 <2.0.0'
   test: ^1.5.3
   webdriver: ^3.0.0


### PR DESCRIPTION
- switch to using `package:lints`
- rev the min. SDK to 2.15 (where the `unawaited` function was introduced)
