### PR TITLE
Use Fetch API in SSE Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.2-dev
+
+- Send `fetch` requests instead of XHR `requests`.
+
 ## 4.1.1
 
 - Apply `keepAlive` logic to `SocketException`s.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 4.1.2-dev
 
-- Send `fetch` requests instead of XHR `requests`.
+- Send `fetch` requests instead of `XHR` requests.
 
 ## 4.1.1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sse
-version: 4.1.1
+version: 4.1.2-dev
 description: >-
   Provides client and server functionality for setting up bi-directional
   communication through Server Sent Events (SSE) and corresponding POST


### PR DESCRIPTION
Use `fetch` requests instead of XHR requests in `sse_client`. 

Manifest V3 Chrome Extensions no longer supports XHR (see https://github.com/dart-lang/http/issues/595#issuecomment-1272727256). Therefore, this PR switches `sse_client` over to using `fetch` requests to unblock the Dart Debug Extension. 

I'm also now closing the connection with an error when something goes wrong with the request. This makes it easier for clients to figure out why their connection was closed, eg:

```
background.dart.js:9165 SSE client failed to send ["DevToolsRequest","appId","L0KWP9nZ5N1ioobPczhOEQ==","instanceId","c35c5e80-6b5b-11ed-8f31-a1a736009ce5","contextId",1,"tabUrl","https://b2607f8b04800100000144d90c0a823621f90000000000000000001.proxy.googlers.com/dart/angular/codelab/example/app/web/index.ddc.html","uriOnly",true]:
 ReferenceError: XMLHttpRequest is not defined
```