### PR TITLE
Add optional `debugKey` parameter to SSE client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.2-dev
+
+- Add an optional `debugKey` parameter to `SseClient` to include in logging.
+
 ## 4.1.1
 
 - Apply `keepAlive` logic to `SocketException`s.

--- a/lib/client/sse_client.dart
+++ b/lib/client/sse_client.dart
@@ -27,7 +27,7 @@ final _requestPool = Pool(1000);
 /// them to the [sink] and listen to messages from the server on the [stream].
 class SseClient extends StreamChannelMixin<String?> {
   final String _clientId;
-  
+
   final _incomingController = StreamController<String>();
 
   final _outgoingController = StreamController<String>();

--- a/lib/client/sse_client.dart
+++ b/lib/client/sse_client.dart
@@ -26,6 +26,8 @@ final _requestPool = Pool(1000);
 /// The client can send any JSON-encodable messages to the server by adding
 /// them to the [sink] and listen to messages from the server on the [stream].
 class SseClient extends StreamChannelMixin<String?> {
+  final String _clientId;
+  
   final _incomingController = StreamController<String>();
 
   final _outgoingController = StreamController<String>();
@@ -36,8 +38,6 @@ class SseClient extends StreamChannelMixin<String?> {
 
   int _lastMessageId = -1;
 
-  late String _clientId;
-
   late EventSource _eventSource;
 
   late String _serverUrl;
@@ -47,12 +47,12 @@ class SseClient extends StreamChannelMixin<String?> {
   /// [serverUrl] is the URL under which the server is listening for
   /// incoming bi-directional SSE connections. [debugKey] is an optional key
   /// that can be used to identify the SSE connection.
-  SseClient(String serverUrl, {String? debugKey}) {
-    var uuid = generateUuidV4();
-    _clientId = debugKey == null ? uuid : '$debugKey-$uuid';
-    _eventSource =
-        EventSource('$serverUrl?sseClientId=$_clientId', withCredentials: true);
+  SseClient(String serverUrl, {String? debugKey})
+      : _clientId = debugKey == null
+            ? generateUuidV4()
+            : '$debugKey-${generateUuidV4()}' {
     _serverUrl = '$serverUrl?sseClientId=$_clientId';
+    _eventSource = EventSource(_serverUrl, withCredentials: true);
     _eventSource.onOpen.first.whenComplete(() {
       _onConnected.complete();
       _outgoingController.stream

--- a/lib/src/server/sse_handler.dart
+++ b/lib/src/server/sse_handler.dart
@@ -264,14 +264,15 @@ class SseHandler {
 
   Future<shelf.Response> _handleIncomingMessage(
       shelf.Request req, String path) async {
+    String? clientId;
     try {
-      var clientId = req.url.queryParameters['sseClientId'];
+      clientId = req.url.queryParameters['sseClientId'];
       var messageId = int.parse(req.url.queryParameters['messageId'] ?? '0');
       var message = await req.readAsString();
       var jsonObject = json.decode(message) as String;
       _connections[clientId]?._addIncomingMessage(messageId, jsonObject);
     } catch (e, st) {
-      _logger.fine('Failed to handle incoming message. $e $st');
+      _logger.fine('[$clientId] Failed to handle incoming message. $e $st');
     }
     return shelf.Response.ok('', headers: {
       'access-control-allow-credentials': 'true',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sse
-version: 4.1.1
+version: 4.1.2-dev
 description: >-
   Provides client and server functionality for setting up bi-directional
   communication through Server Sent Events (SSE) and corresponding POST


### PR DESCRIPTION
The `debugKey` parameter can be used to identify the SSE connection. If provided, the `clientId` is prefaced with the `debugKey`. This PR also changes the logs to include the `clientId`.