### PR TITLE
Format all markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@
 
 ## 3.8.1
 
-- Fix an issue where closing the `SseConnection` stream would result in
-  an error.
+- Fix an issue where closing the `SseConnection` stream would result in an
+  error.
 
 ## 3.8.0
 
@@ -36,8 +36,8 @@
 
 ## 3.7.0
 
-- Deprecate the client's `onOpen` getter. Messages will now be buffered until
-  a connection is established.
+- Deprecate the client's `onOpen` getter. Messages will now be buffered until a
+  connection is established.
 
 ## 3.6.1
 
@@ -48,15 +48,14 @@
 - Improve performance by buffering out of order messages in the server instead
   of the client.
 
-** Note ** This is not modelled as a breaking change as the server can handle
-messages from older clients. However, clients should be using the latest server
-if they require order guarantees.
-
+\*\* Note \*\* This is not modelled as a breaking change as the server can
+handle messages from older clients. However, clients should be using the latest
+server if they require order guarantees.
 
 ## 3.5.0
 
-- Add new `shutdown` methods on `SseHandler` and `SseConnection` to allow closing
-  connections immediately, ignoring any keep-alive periods.
+- Add new `shutdown` methods on `SseHandler` and `SseConnection` to allow
+  closing connections immediately, ignoring any keep-alive periods.
 
 ## 3.4.0
 
@@ -65,14 +64,14 @@ if they require order guarantees.
 
 ## 3.3.0
 
-- Add an `onClose` event to the `SseConnection`. This allows consumers to
-  listen to this event in lue of `sseConnection.sink.done` as that is not
-  guaranteed to fire.
+- Add an `onClose` event to the `SseConnection`. This allows consumers to listen
+  to this event in lue of `sseConnection.sink.done` as that is not guaranteed to
+  fire.
 
 ## 3.2.2
 
-- Fix an issue where `keepAlive` may cause state errors when attempting to
-  send messages on a closed stream.
+- Fix an issue where `keepAlive` may cause state errors when attempting to send
+  messages on a closed stream.
 
 ## 3.2.1
 
@@ -94,21 +93,21 @@ if they require order guarantees.
 - Make `isInKeepAlive` on `SseConnection` private.
 
 **Note that this is a breaking change but in actuality no one should be
-  depending on this API.**
+depending on this API.**
 
 ## 3.1.0
 
 - Add optional `keepAlive` parameter to the `SseHandler`. If `keepAlive` is
-  supplied, the connection will remain active for this period after a
-  disconnect and can be reconnected transparently. If there is no reconnect
-  within that period, the connection will be closed normally.
+  supplied, the connection will remain active for this period after a disconnect
+  and can be reconnected transparently. If there is no reconnect within that
+  period, the connection will be closed normally.
 
 ## 3.0.0
 
 - Add retry logic.
 
-**Possible Breaking Change Error messages may now be delayed up to 5 seconds
-  in the client.**
+**Possible Breaking Change Error messages may now be delayed up to 5 seconds in
+the client.**
 
 ## 2.1.2
 
@@ -144,7 +143,6 @@ if they require order guarantees.
 ## 1.0.0
 
 - Internal cleanup.
-
 
 ## 0.0.1
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,7 @@ Want to contribute? Great! First, read this page (including the small print at
 the end).
 
 ### Before you contribute
+
 Before we can use your code, you must sign the
 [Google Individual Contributor License Agreement](https://cla.developers.google.com/about/google-individual)
 (CLA), which you can do online. The CLA is necessary mainly because you own the
@@ -18,16 +19,21 @@ possibly guide you. Coordinating up front makes it much easier to avoid
 frustration later on.
 
 ### Code reviews
+
 All submissions, including submissions by project members, require review.
 
 ### File headers
+
 All files in the project must start with the following header.
 
-    // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
-    // for details. All rights reserved. Use of this source code is governed by a
-    // BSD-style license that can be found in the LICENSE file.
+```
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+```
 
 ### The small print
+
 Contributions made by corporations are covered by a different agreement than the
 one above, the
 [Software Grant and Corporate Contributor License Agreement](https://developers.google.com/open-source/cla/corporate).

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 [![pub package](https://img.shields.io/pub/v/sse.svg)](https://pub.dev/packages/sse)
 [![package publisher](https://img.shields.io/pub/publisher/sse.svg)](https://pub.dev/packages/sse/publisher)
 
-This package provides support for bi-directional communication through
-Server Sent Events and corresponding POST requests.
+This package provides support for bi-directional communication through Server
+Sent Events and corresponding POST requests.
 
-This package is not intended to be a general purpose SSE package, but instead
-is a bidirectional protocol for use when Websockets are unavailable.
-That is, both the client and the server expose a `sink` and `stream` on which to send
-and receive messages respectively.
+This package is not intended to be a general purpose SSE package, but instead is
+a bidirectional protocol for use when Websockets are unavailable. That is, both
+the client and the server expose a `sink` and `stream` on which to send and
+receive messages respectively.
 
-Both the server and client have implicit assumptions on each other and therefore a
-client from this package must be paired with a server from this package.
+Both the server and client have implicit assumptions on each other and therefore
+a client from this package must be paired with a server from this package.


### PR DESCRIPTION
Ran `mdformat . --wrap=80` on all markdown files with https://mdformat.readthedocs.io/en/stable/