### PR TITLE
Add `package:js` to dependencies

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [dev]
+        sdk: [stable, dev]
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
@@ -47,7 +47,7 @@ jobs:
       matrix:
         # Add macos-latest and/or windows-latest if relevant for this package.
         os: [ubuntu-latest]
-        sdk: [2.15.0, dev]
+        sdk: [stable, dev]
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Send `fetch` requests instead of `XHR` requests.
 - Add an optional `debugKey` parameter to `SseClient` to include in logging.
+- Add a dev dependency on `package:js`.
+- Update the minimum Dart SDK version to `2.16.0`.
 
 ## 4.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Send `fetch` requests instead of `XHR` requests.
 - Add an optional `debugKey` parameter to `SseClient` to include in logging.
-- Add a dev dependency on `package:js`.
+- Add a dependency on `package:js`.
 - Update the minimum Dart SDK version to `2.16.0`.
 
 ## 4.1.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   stream_channel: '>=1.6.8 <3.0.0'
 
 dev_dependencies:
+  js: ^0.6.5
   lints: ^1.0.0
   shelf_static: '>=0.2.8 <2.0.0'
   test: ^1.5.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ description: >-
 repository: https://github.com/dart-lang/sse
 
 environment:
-  sdk: '>=2.15.0 <3.0.0'
+  sdk: '>=2.16.0 <3.0.0'
 
 dependencies:
   async: ^2.0.8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ description: >-
 repository: https://github.com/dart-lang/sse
 
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=2.15.0 <3.0.0'
 
 dependencies:
   async: ^2.0.8
@@ -18,7 +18,7 @@ dependencies:
   stream_channel: '>=1.6.8 <3.0.0'
 
 dev_dependencies:
-  js: ^0.6.5
+  js: ^0.6.4
   lints: ^1.0.0
   shelf_static: '>=0.2.8 <2.0.0'
   test: ^1.5.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,13 +12,13 @@ environment:
 dependencies:
   async: ^2.0.8
   collection: ^1.0.0
+  js: ^0.6.4
   logging: '>=0.11.3+2 <2.0.0'
   pool: ^1.5.0
   shelf: ^1.1.0
   stream_channel: '>=1.6.8 <3.0.0'
 
 dev_dependencies:
-  js: ^0.6.4
   lints: ^1.0.0
   shelf_static: '>=0.2.8 <2.0.0'
   test: ^1.5.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ description: >-
 repository: https://github.com/dart-lang/sse
 
 environment:
-  sdk: '>=2.15.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 
 dependencies:
   async: ^2.0.8


### PR DESCRIPTION
Fixes the following error when I went to publish `package:sse`:

```
Publishing sse 4.1.2 to https://pub.dev:
....
Package validation found the following error:
* line 9, column 1 of lib/client/sse_client.dart: This package does not have js in the `dependencies` section of `pubspec.yaml`.
    ╷
  9 │ import 'package:js/js.dart';
    │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Also updates the min Dart SDK to 2.16.0 for version compatibility with `package:js`