### PR TITLE
Fix incorrect cast causing wasm failure, prepare v4.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.4
+
+- Fix incorrect cast causing failure with `dart2wasm`.
+
 ## 4.1.3
 
 - Update the minimum Dart SDK version to `3.2.0`.

--- a/lib/client/sse_client.dart
+++ b/lib/client/sse_client.dart
@@ -124,8 +124,8 @@ class SseClient extends StreamChannelMixin<String?> {
 
   void _onIncomingMessage(Event message) {
     var decoded =
-        jsonDecode((message as MessageEvent).data as String) as String;
-    _incomingController.add(decoded);
+        jsonDecode(((message as MessageEvent).data as JSString).toDart);
+    _incomingController.add(decoded as String);
   }
 
   void _onOutgoingDone() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sse
-version: 4.1.3
+version: 4.1.4
 description: >-
   Provides client and server functionality for setting up bi-directional
   communication through Server Sent Events (SSE) and corresponding POST


### PR DESCRIPTION
Only hit this bug when actually running in Wasm.

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.