### PR TITLE
Make `SseConnection` extend `StreamChannelMixin<String>`

### DIFF
--- a/lib/src/server/sse_handler.dart
+++ b/lib/src/server/sse_handler.dart
@@ -28,7 +28,7 @@ class _SseMessage {
 }
 
 /// A bi-directional SSE connection between server and browser.
-class SseConnection extends StreamChannelMixin<String?> {
+class SseConnection extends StreamChannelMixin<String> {
   /// Incoming messages from the Browser client.
   final _incomingController = StreamController<String>();
 


### PR DESCRIPTION
I don't see any reason for the type argument to be nullable. Seems like a null safety migration artifact.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

